### PR TITLE
Fix group name in class definition tree

### DIFF
--- a/src/Controller/Admin/DataObject/ClassController.php
+++ b/src/Controller/Admin/DataObject/ClassController.php
@@ -175,7 +175,11 @@ class ClassController extends AdminAbstractController implements KernelControlle
                 }
             }
 
-            $groupName = Translation::getByKeyLocalized($groupName, Translation::DOMAIN_ADMIN, true, true);
+            $groupNameTranslation = Translation::getByKeyLocalized($groupName, Translation::DOMAIN_ADMIN, true, true);
+
+            if (!empty($groupNameTranslation)) {
+                $groupName = $groupNameTranslation;
+            }
 
             if (!isset($groups[$groupName])) {
                 $groups[$groupName] = [


### PR DESCRIPTION
## Situation:
- Open the class definition window
- Create a class definition
- Define a group name that is not stored in the Admin Translation
- Class definition is subgrouped in the "Root" folder

## Expected Behavior:
If the group name has no translation, the class definition should be subgrouped under the specified group name.

## Fix:
It must now be checked here whether there is a translation. If not, the group name should be used.